### PR TITLE
feat: upgrade & version

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -31,8 +31,9 @@ ${title}
 Usage: ${cyan('juno upgrade [options]')}
 
 Options:
-  ${cyan('-s, --src')}           a local wasm file to upgrade your satellite
-  ${cyan('-h, --help')}          output usage information
+  ${cyan('-s, --src')}             a local wasm file for the upgrade
+  ${cyan('-m, --mission-control')} target a mission control instead of satellite (default)
+  ${cyan('-h, --help')}            output usage information
 `;
 
 export const helpCommand = (command: string) => `


### PR DESCRIPTION
- `juno version` = checks version only. "Your satellite v.... is up-to-date." or "Your satelitte v... is behind latest v...."

- `juno upgrade -m ...` = upgrade mission control

- `juno upgrade` = upgrade satellite, no changes here

In addition, add a check to `juno upgrade` to prevent cross semver upgrade (v0.0.2 -> v0.0.4 should first go to v0.0.3)